### PR TITLE
refs #BE-14: Umstellung der Build-Umgebung auf OpenJDK 21, Ersetzung …

### DIFF
--- a/sakai-aws-infrastructure/src/main/java/com/sakai/cloud/infra/stack/PipelineStack.java
+++ b/sakai-aws-infrastructure/src/main/java/com/sakai/cloud/infra/stack/PipelineStack.java
@@ -104,13 +104,14 @@ public class PipelineStack extends Stack {
                 .installCommands(List.of(
                         "npm install -g aws-cdk",
                         "cdk --version",
-                        "yum install -y java-21-amazon-corretto-devel",
-                        "export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto",
+                        "apt-get update",
+                        "apt-get install -y openjdk-21-jdk",
+                        "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64",
                         "export PATH=$JAVA_HOME/bin:$PATH",
                         "java -version"
                 ))
                 .commands(List.of(
-                        "export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto",
+                        "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64",
                         "export PATH=$JAVA_HOME/bin:$PATH",
                         "cd sakai-aws-infrastructure",
                         "cdk synth"


### PR DESCRIPTION
…von Amazon Corretto für optimierte Kompatibilität und Paketverwaltung.